### PR TITLE
Use lates prism source

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require github.com/sourcegraph/go-lsp v0.0.0-20240223163137-f80c5dd31dfd
 
 require (
 	github.com/smacker/go-tree-sitter v0.0.0-20240625050157-a31a98a7c0f6
-	github.com/tjgurwara99/go-ruby-prism v0.0.0-20240723164524-bc9b52afbbc5
+	github.com/tjgurwara99/go-ruby-prism v0.0.1
 )
 
 require github.com/tetratelabs/wazero v1.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,8 @@ github.com/tjgurwara99/go-ruby-prism v0.0.0-20240723155658-73ea4fcee3c2 h1:+XKUq
 github.com/tjgurwara99/go-ruby-prism v0.0.0-20240723155658-73ea4fcee3c2/go.mod h1:K0HRi8NNXJedZTdO0Gc5v/IEM8HTVCDYT2cv8wHimHM=
 github.com/tjgurwara99/go-ruby-prism v0.0.0-20240723164524-bc9b52afbbc5 h1:rTssCx4weRKR5rkto6pBL6v8puUnzC4iOyhYmbS4B4M=
 github.com/tjgurwara99/go-ruby-prism v0.0.0-20240723164524-bc9b52afbbc5/go.mod h1:K0HRi8NNXJedZTdO0Gc5v/IEM8HTVCDYT2cv8wHimHM=
+github.com/tjgurwara99/go-ruby-prism v0.0.1 h1:6Z7oAQBiUaNXvAG3iJAZZWceSkzYrceH96QiBUSWyr4=
+github.com/tjgurwara99/go-ruby-prism v0.0.1/go.mod h1:K0HRi8NNXJedZTdO0Gc5v/IEM8HTVCDYT2cv8wHimHM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=


### PR DESCRIPTION
We made some updates to the latest ruby-prism module we are using for Go. It matches the main branch in the main ruby prism project.